### PR TITLE
require node 16 dues to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/zapccu/ioBroker.sma-ev-charger.git"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"


### PR DESCRIPTION
adapter core 3.x.x is know to fail during install on node 14 as npm 6 does not install peerDependencies. So this adapetr requires node 16 to install without issues.